### PR TITLE
Generic TCP connection pool

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -59,12 +59,20 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "codec_interface",
+    hdrs = ["include/envoy/tcp/codec.h"],
+    repository = "@envoy",
+    deps = ["@envoy//source/exe:envoy_common_lib"],
+)
+
+envoy_cc_library(
     name = "nats_streaming_filter_config_factory",
     srcs = ["nats_streaming_filter_config_factory.cc"],
     hdrs = ["nats_streaming_filter_config_factory.h"],
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
+        ":codec_interface",
         ":nats_streaming_filter_lib",
         "@envoy//source/exe:envoy_common_lib",
     ],

--- a/include/envoy/tcp/BUILD
+++ b/include/envoy/tcp/BUILD
@@ -1,0 +1,26 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "codec_interface",
+    hdrs = ["codec.h"],
+    repository = "@envoy",
+    deps = ["@envoy//include/envoy/buffer:buffer_interface"],
+)
+
+envoy_cc_library(
+    name = "conn_pool_interface",
+    hdrs = ["conn_pool.h"],
+    repository = "@envoy",
+    deps = [
+        ":codec_interface",
+        "@envoy//include/envoy/upstream:cluster_manager_interface",
+    ],
+)

--- a/include/envoy/tcp/codec.h
+++ b/include/envoy/tcp/codec.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/exception.h"
+#include "envoy/common/pure.h"
+
+namespace Envoy {
+namespace Tcp {
+
+template <typename T> using MessagePtr = std::unique_ptr<T>;
+
+/**
+ * Callbacks that the decoder fires.
+ */
+template <typename T> class DecoderCallbacks {
+public:
+  virtual ~DecoderCallbacks() {}
+
+  /**
+   * Called when a new top level value has been decoded.
+   * @param value supplies the decoded value that is now owned by the callee.
+   */
+  virtual void onValue(MessagePtr<T> &&value) PURE;
+};
+
+/**
+ * A byte decoder.
+ */
+class Decoder {
+public:
+  virtual ~Decoder() {}
+
+  /**
+   * Decode protocol bytes.
+   * @param data supplies the data to decode. All bytes will be consumed by the
+   * decoder or a ProtocolError will be thrown.
+   */
+  virtual void decode(Buffer::Instance &data) PURE;
+};
+
+typedef std::unique_ptr<Decoder> DecoderPtr;
+
+/**
+ * A factory for a decoder.
+ */
+template <typename T> class DecoderFactory {
+public:
+  virtual ~DecoderFactory() {}
+
+  /**
+   * Create a decoder given a set of decoder callbacks.
+   */
+  virtual DecoderPtr create(DecoderCallbacks<T> &callbacks) PURE;
+};
+
+/**
+ * A byte encoder.
+ */
+template <typename T> class Encoder {
+public:
+  virtual ~Encoder() {}
+
+  /**
+   * Encode a value to a buffer.
+   * @param value supplies the value to encode.
+   * @param out supplies the buffer to encode to.
+   */
+  virtual void encode(const T &value, Buffer::Instance &out) PURE;
+};
+
+template <typename T> using EncoderPtr = std::unique_ptr<Encoder<T>>;
+
+/**
+ * A protocol error.
+ */
+class ProtocolError : public EnvoyException {
+public:
+  ProtocolError(const std::string &error) : EnvoyException(error) {}
+};
+
+} // namespace Tcp
+} // namespace Envoy

--- a/include/envoy/tcp/conn_pool.h
+++ b/include/envoy/tcp/conn_pool.h
@@ -1,0 +1,143 @@
+#pragma once
+
+#include <memory>
+
+#include "envoy/common/pure.h"
+#include "envoy/event/deferred_deletable.h"
+#include "envoy/network/connection.h"
+#include "envoy/tcp/codec.h"
+#include "envoy/upstream/upstream.h"
+
+namespace Envoy {
+namespace Tcp {
+namespace ConnPool {
+
+/**
+ * A handle to an outbound request.
+ */
+class PoolRequest {
+public:
+  virtual ~PoolRequest() {}
+
+  /**
+   * Cancel the request. No further request callbacks will be called.
+   */
+  virtual void cancel() PURE;
+};
+
+/**
+ * Outbound request callbacks.
+ */
+template <typename T> class PoolCallbacks {
+public:
+  virtual ~PoolCallbacks() {}
+
+  /**
+   * Called when a pipelined response is received.
+   * @param value supplies the response which is now owned by the callee.
+   */
+  virtual void onResponse(MessagePtr<T> &&value) PURE;
+
+  /**
+   * Called when a network/protocol error occurs and there is no response.
+   */
+  virtual void onFailure() PURE;
+};
+
+/**
+ * A single client connection.
+ */
+template <typename T> class Client : public Event::DeferredDeletable {
+public:
+  virtual ~Client() {}
+
+  /**
+   * Adds network connection callbacks to the underlying network connection.
+   */
+  virtual void
+  addConnectionCallbacks(Network::ConnectionCallbacks &callbacks) PURE;
+
+  /**
+   * Closes the underlying network connection.
+   */
+  virtual void close() PURE;
+
+  /**
+   * Make a pipelined request to the remote server.
+   * @param request supplies the RESP request to make.
+   * @param callbacks supplies the request callbacks.
+   * @return PoolRequest* a handle to the active request or nullptr if the
+   * request could not be made for some reason.
+   */
+  virtual PoolRequest *makeRequest(const T &request,
+                                   PoolCallbacks<T> &callbacks) PURE;
+};
+
+template <typename T> using ClientPtr = std::unique_ptr<Client<T>>;
+
+/**
+ * Configuration for a connection pool.
+ */
+class Config {
+public:
+  virtual ~Config() {}
+
+  /**
+   * @return std::chrono::milliseconds the timeout for an individual operation.
+   * Currently, all operations use the same timeout.
+   */
+  virtual std::chrono::milliseconds opTimeout() const PURE;
+
+  /**
+   * @return bool disable outlier events even if the cluster has it enabled.
+   * This is used by the healthchecker's connection pool to avoid double
+   * counting active healthcheck operations as passive healthcheck operations.
+   */
+  virtual bool disableOutlierEvents() const PURE;
+};
+
+/**
+ * A factory for individual client connections.
+ */
+template <typename T> class ClientFactory {
+public:
+  virtual ~ClientFactory() {}
+
+  /**
+   * Create a client given an upstream host.
+   * @param host supplies the upstream host.
+   * @param dispatcher supplies the owning thread's dispatcher.
+   * @param config supplies the connection pool configuration.
+   * @return ClientPtr a new connection pool client.
+   */
+  virtual ClientPtr<T> create(Upstream::HostConstSharedPtr host,
+                              Event::Dispatcher &dispatcher,
+                              const Config &config) PURE;
+};
+
+/**
+ * A connection pool. Wraps M connections to N upstream hosts, consistent
+ * hashing, pipelining, failure handling, etc.
+ */
+template <typename T> class Instance {
+public:
+  virtual ~Instance() {}
+
+  /**
+   * Makes a request.
+   * @param hash_key supplies the key to use for consistent hashing.
+   * @param request supplies the request to make.
+   * @param callbacks supplies the request completion callbacks.
+   * @return PoolRequest* a handle to the active request or nullptr if the
+   * request could not be made for some reason.
+   */
+  virtual PoolRequest *makeRequest(const std::string &hash_key,
+                                   const T &request,
+                                   PoolCallbacks<T> &callbacks) PURE;
+};
+
+template <typename T> using InstancePtr = std::unique_ptr<Instance<T>>;
+
+} // namespace ConnPool
+} // namespace Tcp
+} // namespace Envoy

--- a/source/common/tcp/BUILD
+++ b/source/common/tcp/BUILD
@@ -1,0 +1,39 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "codec_lib",
+    hdrs = ["codec_impl.h"],
+    repository = "@envoy",
+    deps = [
+        "//include/envoy/tcp:codec_interface",
+        "@envoy//source/common/common:assert_lib",
+        "@envoy//source/common/common:logger_lib",
+        "@envoy//source/common/common:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "conn_pool_lib",
+    srcs = ["conn_pool_impl.cc"],
+    hdrs = ["conn_pool_impl.h"],
+    repository = "@envoy",
+    deps = [
+        ":codec_lib",
+        "//include/envoy/tcp:conn_pool_interface",
+        "@envoy//include/envoy/router:router_interface",
+        "@envoy//include/envoy/thread_local:thread_local_interface",
+        "@envoy//include/envoy/upstream:cluster_manager_interface",
+        "@envoy//source/common/buffer:buffer_lib",
+        "@envoy//source/common/common:assert_lib",
+        "@envoy//source/common/network:filter_lib",
+        "@envoy//source/common/protobuf:utility_lib",
+    ],
+)

--- a/source/common/tcp/codec_impl.h
+++ b/source/common/tcp/codec_impl.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "envoy/tcp/codec.h"
+
+namespace Envoy {
+namespace Tcp {
+
+/**
+ * A factory implementation that returns a real decoder.
+ */
+template <typename T, typename D>
+class DecoderFactoryImpl : public DecoderFactory<T> {
+public:
+  // Tcp::DecoderFactory
+  DecoderPtr create(DecoderCallbacks<T> &callbacks) override {
+    return DecoderPtr{new D(callbacks)};
+  }
+};
+
+} // namespace Tcp
+} // namespace Envoy

--- a/source/common/tcp/conn_pool_impl.cc
+++ b/source/common/tcp/conn_pool_impl.cc
@@ -1,0 +1,12 @@
+#include "common/tcp/conn_pool_impl.h"
+
+namespace Envoy {
+namespace Tcp {
+namespace ConnPool {
+
+ConfigImpl::ConfigImpl(const std::chrono::milliseconds &op_timeout)
+    : op_timeout_(op_timeout) {}
+
+} // namespace ConnPool
+} // namespace Tcp
+} // namespace Envoy

--- a/source/common/tcp/conn_pool_impl.h
+++ b/source/common/tcp/conn_pool_impl.h
@@ -1,0 +1,400 @@
+#pragma once
+
+#include "envoy/event/dispatcher.h"
+#include "envoy/network/connection.h"
+#include "envoy/tcp/conn_pool.h"
+#include "envoy/thread_local/thread_local.h"
+#include "envoy/upstream/cluster_manager.h"
+#include "envoy/upstream/upstream.h"
+
+#include "common/buffer/buffer_impl.h"
+#include "common/common/assert.h"
+#include "common/network/filter_impl.h"
+#include "common/tcp/codec_impl.h"
+
+namespace Envoy {
+namespace Tcp {
+namespace ConnPool {
+
+class ConfigImpl : public Config {
+public:
+  ConfigImpl(const std::chrono::milliseconds &op_timeout);
+
+  bool disableOutlierEvents() const override { return false; }
+  std::chrono::milliseconds opTimeout() const override { return op_timeout_; }
+
+private:
+  const std::chrono::milliseconds op_timeout_;
+};
+
+template <typename T>
+class ClientImpl : public Client<T>,
+                   public DecoderCallbacks<T>,
+                   public Network::ConnectionCallbacks {
+public:
+  static ClientPtr<T> create(Upstream::HostConstSharedPtr host,
+                             Event::Dispatcher &dispatcher,
+                             EncoderPtr<T> &&encoder,
+                             DecoderFactory<T> &decoder_factory,
+                             const Config &config) {
+    std::unique_ptr<ClientImpl> client(new ClientImpl(
+        host, dispatcher, std::move(encoder), decoder_factory, config));
+    client->connection_ = host->createConnection(dispatcher).connection_;
+    client->connection_->addConnectionCallbacks(*client);
+    client->connection_->addReadFilter(
+        Network::ReadFilterSharedPtr{new UpstreamReadFilter(*client)});
+    client->connection_->connect();
+    client->connection_->noDelay(true);
+    return std::move(client);
+  }
+
+  ~ClientImpl() {
+    ASSERT(pending_requests_.empty());
+    ASSERT(connection_->state() == Network::Connection::State::Closed);
+    host_->cluster().stats().upstream_cx_active_.dec();
+    host_->stats().cx_active_.dec();
+  }
+
+  // Tcp::ConnPool::Client
+  void
+  addConnectionCallbacks(Network::ConnectionCallbacks &callbacks) override {
+    connection_->addConnectionCallbacks(callbacks);
+  }
+  void close() override {
+    connection_->close(Network::ConnectionCloseType::NoFlush);
+  }
+  PoolRequest *makeRequest(const T &request,
+                           PoolCallbacks<T> &callbacks) override {
+    ASSERT(connection_->state() == Network::Connection::State::Open);
+
+    pending_requests_.emplace_back(*this, callbacks);
+    encoder_->encode(request, encoder_buffer_);
+    connection_->write(encoder_buffer_);
+
+    // Only boost the op timeout if:
+    // - We are not already connected. Otherwise, we are governed by the connect
+    // timeout and the timer
+    //   will be reset when/if connection occurs. This allows a relatively long
+    //   connection spin up time for example if TLS is being used.
+    // - This is the first request on the pipeline. Otherwise the timeout would
+    // effectively start on
+    //   the last operation.
+    if (connected_ && pending_requests_.size() == 1) {
+      connect_or_op_timer_->enableTimer(config_.opTimeout());
+    }
+
+    return &pending_requests_.back();
+  }
+
+private:
+  struct UpstreamReadFilter : public Network::ReadFilterBaseImpl {
+    UpstreamReadFilter(ClientImpl<T> &parent) : parent_(parent) {}
+
+    // Network::ReadFilter
+    Network::FilterStatus onData(Buffer::Instance &data) override {
+      parent_.onData(data);
+      return Network::FilterStatus::Continue;
+    }
+
+    ClientImpl &parent_;
+  };
+
+  struct PendingRequest : public PoolRequest {
+    PendingRequest(ClientImpl &parent, PoolCallbacks<T> &callbacks)
+        : parent_(parent), callbacks_(callbacks) {
+      parent.host_->cluster().stats().upstream_rq_total_.inc();
+      parent.host_->cluster().stats().upstream_rq_active_.inc();
+      parent.host_->stats().rq_total_.inc();
+      parent.host_->stats().rq_active_.inc();
+    }
+    ~PendingRequest() {
+      parent_.host_->cluster().stats().upstream_rq_active_.dec();
+      parent_.host_->stats().rq_active_.dec();
+    }
+
+    // Tcp::ConnPool::PoolRequest
+    void cancel() override {
+      // If we get a cancellation, we just mark the pending request as
+      // cancelled, and then we drop the response as it comes through. There is
+      // no reason to blow away the connection when the remote is already
+      // responding as fast as possible.
+      canceled_ = true;
+    }
+
+    ClientImpl &parent_;
+    PoolCallbacks<T> &callbacks_;
+    bool canceled_{};
+  };
+
+  ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher &dispatcher,
+             EncoderPtr<T> &&encoder, DecoderFactory<T> &decoder_factory,
+             const Config &config)
+      : host_(host), encoder_(std::move(encoder)),
+        decoder_(decoder_factory.create(*this)), config_(config),
+        connect_or_op_timer_(dispatcher.createTimer(
+            [this]() -> void { onConnectOrOpTimeout(); })) {
+    host->cluster().stats().upstream_cx_total_.inc();
+    host->cluster().stats().upstream_cx_active_.inc();
+    host->stats().cx_total_.inc();
+    host->stats().cx_active_.inc();
+    connect_or_op_timer_->enableTimer(host->cluster().connectTimeout());
+  }
+  void onConnectOrOpTimeout() {
+    putOutlierEvent(Upstream::Outlier::Result::TIMEOUT);
+    if (connected_) {
+      host_->cluster().stats().upstream_rq_timeout_.inc();
+    } else {
+      host_->cluster().stats().upstream_cx_connect_timeout_.inc();
+    }
+
+    connection_->close(Network::ConnectionCloseType::NoFlush);
+  }
+  void onData(Buffer::Instance &data) {
+    try {
+      decoder_->decode(data);
+    } catch (ProtocolError &) {
+      putOutlierEvent(Upstream::Outlier::Result::REQUEST_FAILED);
+      host_->cluster().stats().upstream_cx_protocol_error_.inc();
+      connection_->close(Network::ConnectionCloseType::NoFlush);
+    }
+  }
+  void putOutlierEvent(Upstream::Outlier::Result result) {
+    if (!config_.disableOutlierEvents()) {
+      host_->outlierDetector().putResult(result);
+    }
+  }
+
+  // Tcp::DecoderCallbacks
+  void onValue(MessagePtr<T> &&value) override {
+    ASSERT(!pending_requests_.empty());
+    PendingRequest &request = pending_requests_.front();
+    if (!request.canceled_) {
+      request.callbacks_.onResponse(std::move(value));
+    } else {
+      host_->cluster().stats().upstream_rq_cancelled_.inc();
+    }
+    pending_requests_.pop_front();
+
+    // If there are no remaining ops in the pipeline we need to disable the
+    // timer. Otherwise we boost the timer since we are receiving responses and
+    // there are more to flush out.
+    if (pending_requests_.empty()) {
+      connect_or_op_timer_->disableTimer();
+    } else {
+      connect_or_op_timer_->enableTimer(config_.opTimeout());
+    }
+
+    putOutlierEvent(Upstream::Outlier::Result::SUCCESS);
+  }
+
+  // Network::ConnectionCallbacks
+  void onEvent(Network::ConnectionEvent event) override {
+    if (event == Network::ConnectionEvent::RemoteClose ||
+        event == Network::ConnectionEvent::LocalClose) {
+      if (!pending_requests_.empty()) {
+        host_->cluster().stats().upstream_cx_destroy_with_active_rq_.inc();
+        if (event == Network::ConnectionEvent::RemoteClose) {
+          putOutlierEvent(Upstream::Outlier::Result::SERVER_FAILURE);
+          host_->cluster()
+              .stats()
+              .upstream_cx_destroy_remote_with_active_rq_.inc();
+        }
+        if (event == Network::ConnectionEvent::LocalClose) {
+          host_->cluster()
+              .stats()
+              .upstream_cx_destroy_local_with_active_rq_.inc();
+        }
+      }
+
+      while (!pending_requests_.empty()) {
+        PendingRequest &request = pending_requests_.front();
+        if (!request.canceled_) {
+          request.callbacks_.onFailure();
+        } else {
+          host_->cluster().stats().upstream_rq_cancelled_.inc();
+        }
+        pending_requests_.pop_front();
+      }
+
+      connect_or_op_timer_->disableTimer();
+    } else if (event == Network::ConnectionEvent::Connected) {
+      connected_ = true;
+      ASSERT(!pending_requests_.empty());
+      connect_or_op_timer_->enableTimer(config_.opTimeout());
+    }
+
+    if (event == Network::ConnectionEvent::RemoteClose && !connected_) {
+      host_->cluster().stats().upstream_cx_connect_fail_.inc();
+      host_->stats().cx_connect_fail_.inc();
+    }
+  }
+  void onAboveWriteBufferHighWatermark() override {}
+  void onBelowWriteBufferLowWatermark() override {}
+
+  Upstream::HostConstSharedPtr host_;
+  Network::ClientConnectionPtr connection_;
+  EncoderPtr<T> encoder_;
+  Buffer::OwnedImpl encoder_buffer_;
+  DecoderPtr decoder_;
+  const Config &config_;
+  std::list<PendingRequest> pending_requests_;
+  Event::TimerPtr connect_or_op_timer_;
+  bool connected_{};
+};
+
+template <typename T, typename E, typename D>
+class ClientFactoryImpl : public ClientFactory<T> {
+public:
+  // Tcp::ConnPool::ClientFactoryImpl
+  ClientPtr<T> create(Upstream::HostConstSharedPtr host,
+                      Event::Dispatcher &dispatcher,
+                      const Config &config) override {
+    return ClientImpl<T>::create(host, dispatcher, EncoderPtr<T>{new E()},
+                                 decoder_factory_, config);
+  }
+
+  static ClientFactoryImpl<T, E, D> instance_;
+
+private:
+  DecoderFactoryImpl<T, D> decoder_factory_;
+};
+
+template <typename T, typename D> class InstanceImpl : public Instance<T> {
+public:
+  InstanceImpl(const std::string &cluster_name, Upstream::ClusterManager &cm,
+               ClientFactory<T> &client_factory,
+               ThreadLocal::SlotAllocator &tls,
+               const std::chrono::milliseconds &op_timeout)
+      : cm_(cm), client_factory_(client_factory), tls_(tls.allocateSlot()),
+        config_(op_timeout) {
+    tls_->set([this, cluster_name](Event::Dispatcher &dispatcher)
+                  -> ThreadLocal::ThreadLocalObjectSharedPtr {
+      return std::make_shared<ThreadLocalPool>(*this, dispatcher, cluster_name);
+    });
+  }
+
+  // Tcp::ConnPool::Instance
+  PoolRequest *makeRequest(const std::string &hash_key, const T &request,
+                           PoolCallbacks<T> &callbacks) override {
+    return tls_->getTyped<ThreadLocalPool>().makeRequest(hash_key, request,
+                                                         callbacks);
+  }
+
+private:
+  struct ThreadLocalPool;
+
+  struct ThreadLocalActiveClient : public Network::ConnectionCallbacks {
+    ThreadLocalActiveClient(ThreadLocalPool &parent) : parent_(parent) {}
+
+    // Network::ConnectionCallbacks
+    void onEvent(Network::ConnectionEvent event) override {
+      if (event == Network::ConnectionEvent::RemoteClose ||
+          event == Network::ConnectionEvent::LocalClose) {
+        auto client_to_delete = parent_.client_map_.find(host_);
+        ASSERT(client_to_delete != parent_.client_map_.end());
+        parent_.dispatcher_.deferredDelete(
+            std::move(client_to_delete->second->redis_client_));
+        parent_.client_map_.erase(client_to_delete);
+      }
+    }
+    void onAboveWriteBufferHighWatermark() override {}
+    void onBelowWriteBufferLowWatermark() override {}
+
+    ThreadLocalPool &parent_;
+    Upstream::HostConstSharedPtr host_;
+    ClientPtr<T> redis_client_;
+  };
+
+  typedef std::unique_ptr<ThreadLocalActiveClient> ThreadLocalActiveClientPtr;
+
+  struct ThreadLocalPool : public ThreadLocal::ThreadLocalObject {
+    ThreadLocalPool(InstanceImpl &parent, Event::Dispatcher &dispatcher,
+                    const std::string &cluster_name)
+        : parent_(parent), dispatcher_(dispatcher),
+          cluster_(parent_.cm_.get(cluster_name)) {
+
+      // TODO(mattklein123): Redis is not currently safe for use with CDS. In
+      // order to make this work
+      //                     we will need to add thread local cluster removal
+      //                     callbacks so that we can safely clean things up and
+      //                     fail requests.
+      ASSERT(!cluster_->info()->addedViaApi());
+      local_host_set_member_update_cb_handle_ =
+          cluster_->prioritySet().addMemberUpdateCb(
+              [this](uint32_t, const std::vector<Upstream::HostSharedPtr> &,
+                     const std::vector<Upstream::HostSharedPtr> &hosts_removed)
+                  -> void { onHostsRemoved(hosts_removed); });
+    }
+    ~ThreadLocalPool() {
+      local_host_set_member_update_cb_handle_->remove();
+      while (!client_map_.empty()) {
+        client_map_.begin()->second->redis_client_->close();
+      }
+    }
+    PoolRequest *makeRequest(const std::string &hash_key, const T &request,
+                             PoolCallbacks<T> &callbacks) {
+      LbContextImpl lb_context(hash_key);
+      Upstream::HostConstSharedPtr host =
+          cluster_->loadBalancer().chooseHost(&lb_context);
+      if (!host) {
+        return nullptr;
+      }
+
+      ThreadLocalActiveClientPtr &client = client_map_[host];
+      if (!client) {
+        client.reset(new ThreadLocalActiveClient(*this));
+        client->host_ = host;
+        client->redis_client_ =
+            parent_.client_factory_.create(host, dispatcher_, parent_.config_);
+        client->redis_client_->addConnectionCallbacks(*client);
+      }
+
+      return client->redis_client_->makeRequest(request, callbacks);
+    }
+    void
+    onHostsRemoved(const std::vector<Upstream::HostSharedPtr> &hosts_removed) {
+      for (const auto &host : hosts_removed) {
+        auto it = client_map_.find(host);
+        if (it != client_map_.end()) {
+          // We don't currently support any type of draining for redis
+          // connections. If a host is gone, we just close the connection. This
+          // will fail any pending requests.
+          it->second->redis_client_->close();
+        }
+      }
+    }
+
+    InstanceImpl &parent_;
+    Event::Dispatcher &dispatcher_;
+    Upstream::ThreadLocalCluster *cluster_;
+    std::unordered_map<Upstream::HostConstSharedPtr, ThreadLocalActiveClientPtr>
+        client_map_;
+    Common::CallbackHandle *local_host_set_member_update_cb_handle_;
+  };
+
+  struct LbContextImpl : public Upstream::LoadBalancerContext {
+    LbContextImpl(const std::string &hash_key)
+        : hash_key_(std::hash<std::string>()(hash_key)) {}
+    // TODO(danielhochman): convert to HashUtil::xxHash64 when we have a
+    // migration strategy. Upstream::LoadBalancerContext
+    Optional<uint64_t> computeHashKey() override { return hash_key_; }
+    const Router::MetadataMatchCriteria *
+    metadataMatchCriteria() const override {
+      return nullptr;
+    }
+    const Network::Connection *downstreamConnection() const override {
+      return nullptr;
+    }
+
+    const Optional<uint64_t> hash_key_;
+  };
+
+  Upstream::ClusterManager &cm_;
+  ClientFactory<T> &client_factory_;
+  ThreadLocal::SlotPtr tls_;
+  ConfigImpl config_;
+};
+
+} // namespace ConnPool
+} // namespace Tcp
+} // namespace Envoy

--- a/test/common/tcp/BUILD
+++ b/test/common/tcp/BUILD
@@ -1,0 +1,26 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_test(
+    name = "conn_pool_impl_test",
+    srcs = ["conn_pool_impl_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//source/common/tcp:conn_pool_lib",
+        "//test/mocks/tcp:tcp_mocks",
+        "@envoy//source/common/event:dispatcher_lib",
+        "@envoy//source/common/network:utility_lib",
+        "@envoy//source/common/upstream:upstream_includes",
+        "@envoy//source/common/upstream:upstream_lib",
+        "@envoy//test/mocks/network:network_mocks",
+        "@envoy//test/mocks/thread_local:thread_local_mocks",
+        "@envoy//test/mocks/upstream:upstream_mocks",
+    ],
+)

--- a/test/common/tcp/conn_pool_impl_test.cc
+++ b/test/common/tcp/conn_pool_impl_test.cc
@@ -1,0 +1,529 @@
+#include <memory>
+#include <string>
+
+#include "envoy/tcp/codec.h"
+
+#include "common/network/utility.h"
+#include "common/tcp/conn_pool_impl.h"
+#include "common/upstream/upstream_impl.h"
+
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/tcp/mocks.h"
+#include "test/mocks/thread_local/mocks.h"
+#include "test/mocks/upstream/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::Eq;
+using testing::InSequence;
+using testing::Invoke;
+using testing::Ref;
+using testing::Return;
+using testing::ReturnRef;
+using testing::SaveArg;
+using testing::_;
+
+namespace Envoy {
+namespace Tcp {
+namespace ConnPool {
+
+using T = std::string;
+using TPtr = MessagePtr<T>;
+
+std::chrono::milliseconds createConnPoolSettings() {
+  return std::chrono::milliseconds(20);
+}
+
+class TcpClientImplTest : public testing::Test, public DecoderFactory<T> {
+public:
+  // Tcp::DecoderFactory
+  DecoderPtr create(DecoderCallbacks<T> &callbacks) override {
+    callbacks_ = &callbacks;
+    return DecoderPtr{decoder_};
+  }
+
+  ~TcpClientImplTest() {
+    client_.reset();
+
+    // Make sure all gauges are 0.
+    for (const Stats::GaugeSharedPtr &gauge :
+         host_->cluster_.stats_store_.gauges()) {
+      EXPECT_EQ(0U, gauge->value());
+    }
+    for (const Stats::GaugeSharedPtr &gauge : host_->stats_store_.gauges()) {
+      EXPECT_EQ(0U, gauge->value());
+    }
+  }
+
+  void setup() {
+    config_.reset(new ConfigImpl(createConnPoolSettings()));
+    finishSetup();
+  }
+
+  void setup(std::unique_ptr<Config> &&config) {
+    config_ = std::move(config);
+    finishSetup();
+  }
+
+  void finishSetup() {
+    upstream_connection_ = new NiceMock<Network::MockClientConnection>();
+    Upstream::MockHost::MockCreateConnectionData conn_info;
+    conn_info.connection_ = upstream_connection_;
+    EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
+    EXPECT_CALL(*host_, createConnection_(_)).WillOnce(Return(conn_info));
+    EXPECT_CALL(*upstream_connection_, addReadFilter(_))
+        .WillOnce(SaveArg<0>(&upstream_read_filter_));
+    EXPECT_CALL(*upstream_connection_, connect());
+    EXPECT_CALL(*upstream_connection_, noDelay(true));
+
+    client_ = ClientImpl<T>::create(host_, dispatcher_, EncoderPtr<T>{encoder_},
+                                    *this, *config_);
+    EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_total_.value());
+    EXPECT_EQ(1UL, host_->stats_.cx_total_.value());
+  }
+
+  void onConnected() {
+    EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
+    upstream_connection_->raiseEvent(Network::ConnectionEvent::Connected);
+  }
+
+  const std::string cluster_name_{"foo"};
+  std::shared_ptr<Upstream::MockHost> host_{new NiceMock<Upstream::MockHost>()};
+  Event::MockDispatcher dispatcher_;
+  Event::MockTimer *connect_or_op_timer_{new Event::MockTimer(&dispatcher_)};
+  MockEncoder *encoder_{new MockEncoder()};
+  MockDecoder *decoder_{new MockDecoder()};
+  DecoderCallbacks<T> *callbacks_{};
+  NiceMock<Network::MockClientConnection> *upstream_connection_{};
+  Network::ReadFilterSharedPtr upstream_read_filter_;
+  std::unique_ptr<Config> config_;
+  ClientPtr<T> client_;
+};
+
+TEST_F(TcpClientImplTest, Basic) {
+  InSequence s;
+
+  setup();
+
+  T request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest *handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  onConnected();
+
+  T request2;
+  MockPoolCallbacks callbacks2;
+  EXPECT_CALL(*encoder_, encode(Ref(request2), _));
+  PoolRequest *handle2 = client_->makeRequest(request2, callbacks2);
+  EXPECT_NE(nullptr, handle2);
+
+  EXPECT_EQ(2UL, host_->cluster_.stats_.upstream_rq_total_.value());
+  EXPECT_EQ(2UL, host_->cluster_.stats_.upstream_rq_active_.value());
+  EXPECT_EQ(2UL, host_->stats_.rq_total_.value());
+  EXPECT_EQ(2UL, host_->stats_.rq_active_.value());
+
+  Buffer::OwnedImpl fake_data;
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data)))
+      .WillOnce(Invoke([&](Buffer::Instance &) -> void {
+        InSequence s;
+        TPtr response1(new T());
+        EXPECT_CALL(callbacks1, onResponse_(Ref(response1)));
+        EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
+        EXPECT_CALL(host_->outlier_detector_,
+                    putResult(Upstream::Outlier::Result::SUCCESS));
+        callbacks_->onValue(std::move(response1));
+
+        TPtr response2(new T());
+        EXPECT_CALL(callbacks2, onResponse_(Ref(response2)));
+        EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+        EXPECT_CALL(host_->outlier_detector_,
+                    putResult(Upstream::Outlier::Result::SUCCESS));
+        callbacks_->onValue(std::move(response2));
+      }));
+  upstream_read_filter_->onData(fake_data);
+
+  EXPECT_CALL(*upstream_connection_,
+              close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  client_->close();
+}
+
+TEST_F(TcpClientImplTest, Cancel) {
+  InSequence s;
+
+  setup();
+
+  T request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest *handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  onConnected();
+
+  T request2;
+  MockPoolCallbacks callbacks2;
+  EXPECT_CALL(*encoder_, encode(Ref(request2), _));
+  PoolRequest *handle2 = client_->makeRequest(request2, callbacks2);
+  EXPECT_NE(nullptr, handle2);
+
+  handle1->cancel();
+
+  Buffer::OwnedImpl fake_data;
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data)))
+      .WillOnce(Invoke([&](Buffer::Instance &) -> void {
+        InSequence s;
+
+        TPtr response1(new T());
+        EXPECT_CALL(callbacks1, onResponse_(_)).Times(0);
+        EXPECT_CALL(*connect_or_op_timer_, enableTimer(_));
+        EXPECT_CALL(host_->outlier_detector_,
+                    putResult(Upstream::Outlier::Result::SUCCESS));
+        callbacks_->onValue(std::move(response1));
+
+        TPtr response2(new T());
+        EXPECT_CALL(callbacks2, onResponse_(Ref(response2)));
+        EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+        EXPECT_CALL(host_->outlier_detector_,
+                    putResult(Upstream::Outlier::Result::SUCCESS));
+        callbacks_->onValue(std::move(response2));
+      }));
+  upstream_read_filter_->onData(fake_data);
+
+  EXPECT_CALL(*upstream_connection_,
+              close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  client_->close();
+
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_rq_cancelled_.value());
+}
+
+TEST_F(TcpClientImplTest, FailAll) {
+  InSequence s;
+
+  setup();
+
+  NiceMock<Network::MockConnectionCallbacks> connection_callbacks;
+  client_->addConnectionCallbacks(connection_callbacks);
+
+  T request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest *handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  onConnected();
+
+  EXPECT_CALL(host_->outlier_detector_,
+              putResult(Upstream::Outlier::Result::SERVER_FAILURE));
+  EXPECT_CALL(callbacks1, onFailure());
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  EXPECT_CALL(connection_callbacks,
+              onEvent(Network::ConnectionEvent::RemoteClose));
+  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  EXPECT_EQ(1UL,
+            host_->cluster_.stats_.upstream_cx_destroy_with_active_rq_.value());
+  EXPECT_EQ(1UL, host_->cluster_.stats_
+                     .upstream_cx_destroy_remote_with_active_rq_.value());
+}
+
+TEST_F(TcpClientImplTest, FailAllWithCancel) {
+  InSequence s;
+
+  setup();
+
+  NiceMock<Network::MockConnectionCallbacks> connection_callbacks;
+  client_->addConnectionCallbacks(connection_callbacks);
+
+  T request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest *handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  onConnected();
+  handle1->cancel();
+
+  EXPECT_CALL(callbacks1, onFailure()).Times(0);
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  EXPECT_CALL(connection_callbacks,
+              onEvent(Network::ConnectionEvent::LocalClose));
+  upstream_connection_->raiseEvent(Network::ConnectionEvent::LocalClose);
+
+  EXPECT_EQ(1UL,
+            host_->cluster_.stats_.upstream_cx_destroy_with_active_rq_.value());
+  EXPECT_EQ(
+      1UL,
+      host_->cluster_.stats_.upstream_cx_destroy_local_with_active_rq_.value());
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_rq_cancelled_.value());
+}
+
+TEST_F(TcpClientImplTest, ProtocolError) {
+  InSequence s;
+
+  setup();
+
+  T request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest *handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  onConnected();
+
+  Buffer::OwnedImpl fake_data;
+  EXPECT_CALL(*decoder_, decode(Ref(fake_data)))
+      .WillOnce(Invoke(
+          [&](Buffer::Instance &) -> void { throw ProtocolError("error"); }));
+  EXPECT_CALL(host_->outlier_detector_,
+              putResult(Upstream::Outlier::Result::REQUEST_FAILED));
+  EXPECT_CALL(*upstream_connection_,
+              close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(callbacks1, onFailure());
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  upstream_read_filter_->onData(fake_data);
+
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_protocol_error_.value());
+}
+
+TEST_F(TcpClientImplTest, ConnectFail) {
+  InSequence s;
+
+  setup();
+
+  T request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest *handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  EXPECT_CALL(host_->outlier_detector_,
+              putResult(Upstream::Outlier::Result::SERVER_FAILURE));
+  EXPECT_CALL(callbacks1, onFailure());
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_connect_fail_.value());
+  EXPECT_EQ(1UL, host_->stats_.cx_connect_fail_.value());
+}
+
+class ConfigOutlierDisabled : public Config {
+  bool disableOutlierEvents() const override { return true; }
+  std::chrono::milliseconds opTimeout() const override {
+    return std::chrono::milliseconds(25);
+  }
+};
+
+TEST_F(TcpClientImplTest, OutlierDisabled) {
+  InSequence s;
+
+  setup(std::make_unique<ConfigOutlierDisabled>());
+
+  T request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest *handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  EXPECT_CALL(host_->outlier_detector_, putResult(_)).Times(0);
+  EXPECT_CALL(callbacks1, onFailure());
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_connect_fail_.value());
+  EXPECT_EQ(1UL, host_->stats_.cx_connect_fail_.value());
+}
+
+TEST_F(TcpClientImplTest, ConnectTimeout) {
+  InSequence s;
+
+  setup();
+
+  T request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest *handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  EXPECT_CALL(host_->outlier_detector_,
+              putResult(Upstream::Outlier::Result::TIMEOUT));
+  EXPECT_CALL(*upstream_connection_,
+              close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(callbacks1, onFailure());
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  connect_or_op_timer_->callback_();
+
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_connect_timeout_.value());
+}
+
+TEST_F(TcpClientImplTest, OpTimeout) {
+  InSequence s;
+
+  setup();
+
+  T request1;
+  MockPoolCallbacks callbacks1;
+  EXPECT_CALL(*encoder_, encode(Ref(request1), _));
+  PoolRequest *handle1 = client_->makeRequest(request1, callbacks1);
+  EXPECT_NE(nullptr, handle1);
+
+  onConnected();
+
+  EXPECT_CALL(host_->outlier_detector_,
+              putResult(Upstream::Outlier::Result::TIMEOUT));
+  EXPECT_CALL(*upstream_connection_,
+              close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(callbacks1, onFailure());
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  connect_or_op_timer_->callback_();
+
+  EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_rq_timeout_.value());
+}
+
+TEST(TcpClientFactoryImplTest, Basic) {
+  ClientFactoryImpl<T, MockEncoder, MockDecoder> factory;
+  Upstream::MockHost::MockCreateConnectionData conn_info;
+  conn_info.connection_ = new NiceMock<Network::MockClientConnection>();
+  std::shared_ptr<Upstream::MockHost> host(new NiceMock<Upstream::MockHost>());
+  EXPECT_CALL(*host, createConnection_(_)).WillOnce(Return(conn_info));
+  NiceMock<Event::MockDispatcher> dispatcher;
+  ConfigImpl config(createConnPoolSettings());
+  ClientPtr<T> client = factory.create(host, dispatcher, config);
+  client->close();
+}
+
+class TcpConnPoolImplTest : public testing::Test, public ClientFactory<T> {
+public:
+  TcpConnPoolImplTest() {
+    conn_pool_.reset(new InstanceImpl<T, MockDecoder>(
+        cluster_name_, cm_, *this, tls_, createConnPoolSettings()));
+  }
+
+  // Tcp::ConnPool::ClientFactory
+  ClientPtr<T> create(Upstream::HostConstSharedPtr host, Event::Dispatcher &,
+                      const Config &) override {
+    return ClientPtr<T>{create_(host)};
+  }
+
+  MOCK_METHOD1(create_, Client<T> *(Upstream::HostConstSharedPtr host));
+
+  const std::string cluster_name_{"foo"};
+  NiceMock<Upstream::MockClusterManager> cm_;
+  NiceMock<ThreadLocal::MockInstance> tls_;
+  InstancePtr<T> conn_pool_;
+};
+
+TEST_F(TcpConnPoolImplTest, Basic) {
+  InSequence s;
+
+  T value;
+  MockPoolRequest active_request;
+  MockPoolCallbacks callbacks;
+  MockClient *client = new NiceMock<MockClient>();
+
+  EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
+      .WillOnce(Invoke([&](Upstream::LoadBalancerContext *context)
+                           -> Upstream::HostConstSharedPtr {
+        EXPECT_EQ(context->computeHashKey().value(),
+                  std::hash<std::string>()("foo"));
+        return cm_.thread_local_cluster_.lb_.host_;
+      }));
+  EXPECT_CALL(*this, create_(_)).WillOnce(Return(client));
+  EXPECT_CALL(*client, makeRequest(Ref(value), Ref(callbacks)))
+      .WillOnce(Return(&active_request));
+  PoolRequest *request = conn_pool_->makeRequest("foo", value, callbacks);
+  EXPECT_EQ(&active_request, request);
+
+  EXPECT_CALL(*client, close());
+  tls_.shutdownThread();
+};
+
+TEST_F(TcpConnPoolImplTest, HostRemove) {
+  InSequence s;
+  MockPoolCallbacks callbacks;
+
+  T value;
+  std::shared_ptr<Upstream::Host> host1(new Upstream::MockHost());
+  std::shared_ptr<Upstream::Host> host2(new Upstream::MockHost());
+  MockClient *client1 = new NiceMock<MockClient>();
+  MockClient *client2 = new NiceMock<MockClient>();
+
+  EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
+      .WillOnce(Return(host1));
+  EXPECT_CALL(*this, create_(Eq(host1))).WillOnce(Return(client1));
+
+  MockPoolRequest active_request1;
+  EXPECT_CALL(*client1, makeRequest(Ref(value), Ref(callbacks)))
+      .WillOnce(Return(&active_request1));
+  PoolRequest *request1 = conn_pool_->makeRequest("foo", value, callbacks);
+  EXPECT_EQ(&active_request1, request1);
+
+  EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
+      .WillOnce(Return(host2));
+  EXPECT_CALL(*this, create_(Eq(host2))).WillOnce(Return(client2));
+
+  MockPoolRequest active_request2;
+  EXPECT_CALL(*client2, makeRequest(Ref(value), Ref(callbacks)))
+      .WillOnce(Return(&active_request2));
+  PoolRequest *request2 = conn_pool_->makeRequest("bar", value, callbacks);
+  EXPECT_EQ(&active_request2, request2);
+
+  EXPECT_CALL(*client2, close());
+  cm_.thread_local_cluster_.cluster_.prioritySet()
+      .getMockHostSet(0)
+      ->runCallbacks({}, {host2});
+
+  EXPECT_CALL(*client1, close());
+  tls_.shutdownThread();
+}
+
+TEST_F(TcpConnPoolImplTest, DeleteFollowedByClusterUpdateCallback) {
+  conn_pool_.reset();
+
+  std::shared_ptr<Upstream::Host> host(new Upstream::MockHost());
+  cm_.thread_local_cluster_.cluster_.prioritySet()
+      .getMockHostSet(0)
+      ->runCallbacks({}, {host});
+}
+
+TEST_F(TcpConnPoolImplTest, NoHost) {
+  InSequence s;
+
+  T value;
+  MockPoolCallbacks callbacks;
+  EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
+      .WillOnce(Return(nullptr));
+  PoolRequest *request = conn_pool_->makeRequest("foo", value, callbacks);
+  EXPECT_EQ(nullptr, request);
+
+  tls_.shutdownThread();
+}
+
+TEST_F(TcpConnPoolImplTest, RemoteClose) {
+  InSequence s;
+
+  T value;
+  MockPoolRequest active_request;
+  MockPoolCallbacks callbacks;
+  MockClient *client = new NiceMock<MockClient>();
+
+  EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_));
+  EXPECT_CALL(*this, create_(_)).WillOnce(Return(client));
+  EXPECT_CALL(*client, makeRequest(Ref(value), Ref(callbacks)))
+      .WillOnce(Return(&active_request));
+  conn_pool_->makeRequest("foo", value, callbacks);
+
+  EXPECT_CALL(tls_.dispatcher_, deferredDelete_(_));
+  client->raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  tls_.shutdownThread();
+}
+
+} // namespace ConnPool
+} // namespace Tcp
+} // namespace Envoy

--- a/test/mocks/tcp/BUILD
+++ b/test/mocks/tcp/BUILD
@@ -1,0 +1,21 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_mock",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_mock(
+    name = "tcp_mocks",
+    srcs = ["mocks.cc"],
+    hdrs = ["mocks.h"],
+    repository = "@envoy",
+    deps = [
+        "//include/envoy/tcp:conn_pool_interface",
+        "//source/common/tcp:codec_lib",
+        "@envoy//source/common/common:assert_lib",
+    ],
+)

--- a/test/mocks/tcp/mocks.cc
+++ b/test/mocks/tcp/mocks.cc
@@ -1,0 +1,66 @@
+#include "mocks.h"
+
+#include "common/common/assert.h"
+#include "common/common/macros.h"
+
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::Invoke;
+using testing::_;
+
+namespace Envoy {
+namespace Tcp {
+
+MockEncoder::MockEncoder() {
+  ON_CALL(*this, encode(_, _))
+      .WillByDefault(Invoke(
+          [this](const std::string &value, Buffer::Instance &out) -> void {
+            encodeSimpleString(value, out);
+          }));
+}
+
+MockEncoder::~MockEncoder() {}
+
+void MockEncoder::encodeSimpleString(const std::string &string,
+                                     Buffer::Instance &out) {
+  out.add("+", 1);
+  out.add(string);
+  out.add("\r\n", 2);
+}
+
+MockDecoder::MockDecoder() {}
+
+MockDecoder::MockDecoder(DecoderCallbacks<T> &callbacks) {
+  UNREFERENCED_PARAMETER(callbacks);
+}
+
+MockDecoder::~MockDecoder() {}
+
+namespace ConnPool {
+
+MockClient::MockClient() {
+  ON_CALL(*this, addConnectionCallbacks(_))
+      .WillByDefault(
+          Invoke([this](Network::ConnectionCallbacks &callbacks) -> void {
+            callbacks_.push_back(&callbacks);
+          }));
+  ON_CALL(*this, close()).WillByDefault(Invoke([this]() -> void {
+    raiseEvent(Network::ConnectionEvent::LocalClose);
+  }));
+}
+
+MockClient::~MockClient() {}
+
+MockPoolRequest::MockPoolRequest() {}
+MockPoolRequest::~MockPoolRequest() {}
+
+MockPoolCallbacks::MockPoolCallbacks() {}
+MockPoolCallbacks::~MockPoolCallbacks() {}
+
+} // namespace ConnPool
+
+} // namespace Tcp
+} // namespace Envoy

--- a/test/mocks/tcp/mocks.h
+++ b/test/mocks/tcp/mocks.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/tcp/codec.h"
+#include "envoy/tcp/conn_pool.h"
+
+#include "common/tcp/codec_impl.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Tcp {
+
+using T = std::string;
+using TPtr = MessagePtr<T>;
+
+class MockEncoder : public Encoder<T> {
+public:
+  MockEncoder();
+  ~MockEncoder();
+
+  MOCK_METHOD2(encode, void(const T &value, Buffer::Instance &out));
+
+private:
+  void encodeSimpleString(const T &string, Buffer::Instance &out);
+};
+
+class MockDecoder : public Decoder {
+public:
+  MockDecoder();
+  MockDecoder(DecoderCallbacks<T> &callbacks);
+  ~MockDecoder();
+
+  MOCK_METHOD1(decode, void(Buffer::Instance &data));
+};
+
+namespace ConnPool {
+
+class MockClient : public Client<T> {
+public:
+  MockClient();
+  ~MockClient();
+
+  void raiseEvent(Network::ConnectionEvent event) {
+    for (Network::ConnectionCallbacks *callbacks : callbacks_) {
+      callbacks->onEvent(event);
+    }
+  }
+
+  MOCK_METHOD1(addConnectionCallbacks,
+               void(Network::ConnectionCallbacks &callbacks));
+  MOCK_METHOD0(close, void());
+  MOCK_METHOD2(makeRequest,
+               PoolRequest *(const T &request, PoolCallbacks<T> &callbacks));
+
+  std::list<Network::ConnectionCallbacks *> callbacks_;
+};
+
+class MockPoolRequest : public PoolRequest {
+public:
+  MockPoolRequest();
+  ~MockPoolRequest();
+
+  MOCK_METHOD0(cancel, void());
+};
+
+class MockPoolCallbacks : public PoolCallbacks<T> {
+public:
+  MockPoolCallbacks();
+  ~MockPoolCallbacks();
+
+  void onResponse(TPtr &&value) override { onResponse_(value); }
+
+  MOCK_METHOD1(onResponse_, void(TPtr &value));
+  MOCK_METHOD0(onFailure, void());
+};
+
+} // namespace ConnPool
+
+} // namespace Tcp
+} // namespace Envoy


### PR DESCRIPTION
1. Introduce a generic TCP connection pool.
   The implementation is based on `Redis::ConnPool::InstanceImpl`.
2. Adapt the unit tests to use a a simple string as a mock message type.
   To run the the tests:
   `bazel test //test/common/tcp:conn_pool_impl_test`